### PR TITLE
Split out setup.cfg from pyproject.toml

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -72,6 +72,10 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: |
+            setup.cfg
+            requirements-dev.txt
       - name: Checkout the source code
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -35,6 +35,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_LATEST }}
+          cache: pip
       - run: python -m pip install build
         name: Install core libraries for build and install
       - name: Build artifacts
@@ -68,6 +69,10 @@ jobs:
           - python-version: "~3.12.0-0"
             experimental: true
     steps:
+      - name: Checkout the source code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -76,13 +81,9 @@ jobs:
           cache-dependency-path: |
             setup.cfg
             requirements-dev.txt
-      - name: Checkout the source code
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
       - name: Install dependencies
         run: |
-          pip install -r requirements-dev.txt
+          pip install -U -r requirements-dev.txt
       - name: Run tests
         run: python -m pytest --cov=aiomonitor -v tests
       - name: Upload coverage data

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
         python-version: ${{ env.PYTHON_LATEST }}
         cache: pip
         cache-dependency-path: |
-          pyproject.toml
+          setup.cfg
           requirements-dev.txt
     - name: Install dependencies
       run: |
@@ -54,9 +54,8 @@ jobs:
         check-latest: true
         cache: pip
         cache-dependency-path: |
-          pyproject.toml
+          setup.cfg
           requirements-dev.txt
-          requirements-doc.txt
     - name: Install dependencies
       run: |
         pip install -U -r requirements-dev.txt
@@ -79,9 +78,8 @@ jobs:
         check-latest: true
         cache: pip
         cache-dependency-path: |
-          pyproject.toml
+          setup.cfg
           requirements-dev.txt
-          requirements-doc.txt
     - name: Install dependencies
       run: |
         pip install -U -r requirements-dev.txt
@@ -104,9 +102,8 @@ jobs:
         check-latest: true
         cache: pip
         cache-dependency-path: |
-          pyproject.toml
+          setup.cfg
           requirements-dev.txt
-          requirements-doc.txt
     - name: Install dependencies
       run: |
         pip install -U -r requirements-dev.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,51 +2,6 @@
 requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
-[project]
-name = "aiomonitor"
-description = "Adds monitor and Python REPL capabilities for asyncio applications"
-readme = {file = "README.rst", content-type = "text/x-rst"}
-license = {file = "LICENSE"}
-authors = [
-    {name = "Nikolay Novik", email = "nickolainovik@gmail.com"},
-]
-maintainers = [
-    {name = "Joongi Kim", email = "me@daybreaker.info"},
-]
-classifiers = [
-    "License :: OSI Approved :: MIT License",
-    "Intended Audience :: Developers",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Operating System :: POSIX",
-    "Development Status :: 3 - Alpha",
-    "Framework :: AsyncIO",
-]
-
-dynamic = ["version"]
-
-requires-python = ">=3.8"
-dependencies = [
-    "attrs>=20",
-    "click>=8",
-    "janus>=1.0",
-    "terminaltables",
-    "typing-extensions>=4.1",
-    "prompt_toolkit>=3.0",
-    "aioconsole",
-]
-
-[project.urls]
-homepage = "https://github.com/aio-libs/aiomonitor"
-documentation = "https://aiomonitor.readthedocs.io"
-repository = "https://github.com/aio-libs/aiomonitor"
-issues = "https://github.com/aio-libs/aiomonitor/issues"
-changelog = "https://github.com/aio-libs/aiomonitor/blob/main/CHANGES.rst"
-chat = "https://matrix.to/#/%23aio-libs:matrix.org"
-
 [tool.setuptools_scm]
 # enables setuptools_scm to provide the dynamic version
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,53 @@
+[metadata]
+name = aiomonitor
+version = attr: aiomonitor.__version__
+author = Nikolay Novik
+author_email = nickolainovik@gmail.com
+maintainer = Joongi Kim
+maintainer_email = me@daybreaker.info
+description = Adds monitor and Python REPL capabilities for asyncio applications
+long_description = file: README.rst, CHANGES.rst
+keywords = asyncio, aiohttp, monitor, debugging, utility, devtool
+license = Apache-2.0
+license_files = LICENSE
+classifiers =
+    License :: OSI Approved :: MIT License
+    Intended Audience :: Developers
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Operating System :: POSIX
+    Development Status :: 3 - Alpha
+    Framework :: AsyncIO
+platforms = POSIX
+download_url = https://pypi.org/project/aiomonitor
+project_urls =
+    Homepage = https://github.com/aio-libs/aiomonitor
+    Documentation = https://aiomonitor.readthedocs.io
+    Repository = https://github.com/aio-libs/aiomonitor
+    Issues = https://github.com/aio-libs/aiomonitor/issues
+    Changelog = https://github.com/aio-libs/aiomonitor/blob/main/CHANGES.rst
+    Chat = https://matrix.to/#/!aio-libs:matrix.org
+
+[options]
+zip_safe = False
+include_package_data = True
+packages = find:
+python_requires = >=3.8
+install_requires =
+    attrs>=20
+    click>=8
+    janus>=1.0
+    terminaltables
+    typing-extensions>=4.1
+    prompt_toolkit>=3.0
+    aioconsole
+
+[options.packages.find]
+exclude =
+    examples/*
+    tools/*
+    .*.yml
+    *.egg-info


### PR DESCRIPTION
This PR splits out `setup.cfg` from `pyproject.toml` as requested by @webknjaz. :wink: