### PR TITLE
Change the default port numbers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ Pipfile.lock
 
 .pytest_cache
 .python-version
+.*rc
 
 .DS_Store
 ._.DS_Store

--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,7 @@ Monitor has context manager interface:
 
 Now from separate terminal it is possible to connect to the application::
 
-    $ telnet localhost 50101
+    $ telnet localhost 20101
 
 or the included python client::
 
@@ -113,7 +113,7 @@ Let's save this code in file ``simple_srv.py``, so we can run it with the follow
 And now one can connect to a running application from a separate terminal, with
 the ``telnet`` command, and ``aiomonitor`` will immediately respond with prompt::
 
-    $ telnet localhost 50101
+    $ telnet localhost 20101
     Asyncio Monitor: 1 tasks running
     Type help for commands
     monitor >>>

--- a/aiomonitor/__init__.py
+++ b/aiomonitor/__init__.py
@@ -7,7 +7,7 @@ To enable the monitor, just use context manager protocol with start function::
 
     loop = asyncio.get_event_loop()
     with aiomonitor.start_monitor():
-        print("Now you can connect with: nc localhost 50101")
+        print("Now you can connect with: nc localhost 20101")
         loop.run_forever()
 
 Alternatively you can use more verbose try/finally approach::
@@ -22,15 +22,17 @@ Alternatively you can use more verbose try/finally approach::
 
 from importlib.metadata import version
 
-from .monitor import MONITOR_TERMUI_PORT  # for backward compatibility
 from .monitor import (
     CONSOLE_PORT,
     MONITOR_HOST,
+    MONITOR_TERMUI_PORT,
     MONITOR_WEBUI_PORT,
     Monitor,
     start_monitor,
 )
 from .termui.commands import monitor_cli
+
+MONITOR_PORT = MONITOR_TERMUI_PORT  # for backward compatibility
 
 __all__ = (
     "Monitor",

--- a/aiomonitor/monitor.py
+++ b/aiomonitor/monitor.py
@@ -65,9 +65,9 @@ __all__ = (
 log = logging.getLogger(__name__)
 
 MONITOR_HOST: Final = "127.0.0.1"
-MONITOR_TERMUI_PORT: Final = 50101
-CONSOLE_PORT: Final = 50102
-MONITOR_WEBUI_PORT: Final = 50201
+MONITOR_TERMUI_PORT: Final = 20101
+MONITOR_WEBUI_PORT: Final = 20102
+CONSOLE_PORT: Final = 20103
 
 T = TypeVar("T")
 T_co = TypeVar("T_co", covariant=True)

--- a/changes/374.feature.md
+++ b/changes/374.feature.md
@@ -1,0 +1,1 @@
+Replace the default port numbers for the terminal UI, the web UI, and the console access (50101, 50201, 50102 -> 20101, 20102, 20103 respectively)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -12,7 +12,7 @@ simple as opening a file.
 
     loop = asyncio.get_event_loop()
     with aiomonitor.start_monitor(loop):
-        print("Now you can connect with: nc localhost 50101")
+        print("Now you can connect with: nc localhost 20101")
         loop.run_forever()
 
 Alternatively you can use more verbose try/finally approach but do not forget
@@ -40,14 +40,22 @@ Reference
 
 .. data:: MONITOR_HOST = '127.0.0.1'
 
-    Specifies the default host for monitor, by default monitor binded to
-    ``localhost``.
+    Specifies the default host to bind the services for the monitor
 
-.. data:: MONITOR_PORT = 50101
+    .. warning::
 
-    Specifies the default port for monitor, you can connect using telnet client
+       Since aiomonitor exposes the internal states of the traced process, never bind it to
+       publicly accessible address to prevent potential security breaches and denial of services!
 
-.. data:: CONSOLE_PORT = 50102
+.. data:: MONITOR_TERMUI_PORT = 20101
+
+    Specifies the default telnet port for teh monitor where you can connect using a telnet client
+
+.. data:: MONITOR_WEBUI_PORT = 20102
+
+    Specifies the default HTTP port for the monitor where you can connect using a web browser
+
+.. data:: CONSOLE_PORT = 20103
 
     Specifies the default port for asynchronous python REPL
 
@@ -59,9 +67,9 @@ Reference
 
     :param Type[Monitor] monitor: Monitor class to use
     :param str host: hostname to serve monitor telnet server
-    :param int port: monitor port (terminal UI), by default 50101
-    :param int webui_port: monitor port (web UI), by default 50201
-    :param int console_port: python REPL port, by default 50102
+    :param int port: monitor port (terminal UI), by default 20101
+    :param int webui_port: monitor port (web UI), by default 20102
+    :param int console_port: python REPL port, by default 20103
     :param bool console_enabled: flag indicates if python REPL is requred
         to start with instance of monitor.
     :param dict locals: dictionary with variables exposed in python console

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -45,7 +45,7 @@ And now it is possible to connect to the running application from separate
 terminal, by execution ``nc`` command, immediately ``aiomonitor`` will
 respond with prompt::
 
-    $ nc localhost 50101
+    $ telnet localhost 20101
     Asyncio Monitor: 1 tasks running
     Type help for commands
     monitor >>>


### PR DESCRIPTION
## What do these changes do?

The termui/webui/console ports are changed from 50101, 50201, 50102 to 20101, 20102, 20103 respectively.

## Are there changes in behavior for the user?

If the users have relied on the default port numbers, they need to check the
availability of the new default port numbers and/or change their commands or
scripts.

## Related issue number

resolves #373

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
