### PR TITLE
Use the latest version of Black and use the new mirror to speed up

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,8 +9,8 @@ repos:
   - id: check-yaml
   - id: end-of-file-fixer
   - id: trailing-whitespace
-- repo: https://github.com/psf/black
-  rev: 23.3.0
+- repo: https://github.com/psf/black-pre-commit-mirror
+  rev: 23.9.0
   hooks:
   - id: black
 - repo: https://github.com/PyCQA/flake8

--- a/changes/379.misc.md
+++ b/changes/379.misc.md
@@ -1,0 +1,1 @@
+Update the black formatter (23.3.0 -> 23.9.0) and adopt the new pre-commit optimized mirror


### PR DESCRIPTION
## What do these changes do?

Update the Black formatter version (23.3.0 -> 23.9.0) and use the new pre-commit mirror to further speed up.
(ref: https://github.com/psf/black/releases/tag/23.9.0)

## Are there changes in behavior for the user?

No.

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
