### PR TITLE
Improve Python 3.12 compatibility

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -17,7 +17,7 @@ env:
   FORCE_COLOR: "1"  # Make tools pretty.
   PIP_DISABLE_PIP_VERSION_CHECK: "1"
   PIP_NO_PYTHON_VERSION_WARNING: "1"
-  PYTHON_LATEST: "3.11"
+  PYTHON_LATEST: "3.12"
 
   # For re-actors/checkout-python-sdist
   sdist-artifact: python-package-distributions
@@ -69,10 +69,11 @@ jobs:
         - "3.9"
         - "3.10"
         - "3.11"
+        - "3.12"
         experimental: [false]
-        include:
-        - python-version: "~3.12.0-0"
-          experimental: true
+        # include:
+        # - python-version: "~3.12.0-0"
+        #   experimental: true
     steps:
     - name: Checkout the source code
       uses: actions/checkout@v4

--- a/changes/389.fix.md
+++ b/changes/389.fix.md
@@ -1,0 +1,1 @@
+Relax our direct dependnecy version range of aiohttp to allow the new 3.9 series for Python 3.12 support

--- a/changes/389.fix.md
+++ b/changes/389.fix.md
@@ -1,1 +1,1 @@
-Relax our direct dependnecy version range of aiohttp to allow the new 3.9 series for Python 3.12 support
+Relaxed our direct dependnecy version range of aiohttp ("3.8.5 only" to "3.8.5 and higher") to enable installation on Python 3.12

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 -e .
-aioconsole==0.6.1
+aioconsole==0.7.0
 aiohttp==3.8.5
 aiotools==1.6.0
 attrs==23.1.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,5 +19,5 @@ pytest==7.4.0
 terminaltables==3.1.10
 towncrier==23.6.0
 types-requests
-uvloop==0.17.0
+uvloop==0.19.0
 build==0.10.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 -e .
 aioconsole==0.7.0
-aiohttp==3.8.5
+aiohttp==3.9.1
 aiotools==1.6.0
 attrs==23.1.0
 black==22.10.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,8 +38,8 @@ packages = find:
 python_requires = >=3.8
 install_requires =
     attrs>=20
-    aiohttp~=3.8.5
-    click>=8
+    aiohttp>=3.8.5
+    click>=8.0
     janus>=1.0
     jinja2>=3.1.2
     backports.strenum>=1.2.4; python_version<"3.11"

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ install_requires =
     trafaret>=2.1.1
     typing-extensions>=4.1
     prompt_toolkit>=3.0
-    aioconsole
+    aioconsole>=0.7.0
 
 [options.packages.find]
 exclude =

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -255,8 +255,10 @@ async def test_monitor_with_console(monitor: Monitor) -> None:
                 await asyncio.sleep(0.2)
                 try:
                     pipe_input.send_text("await asyncio.sleep(0.1, result=333)\r\n")
+                    pipe_input.flush()
                     await asyncio.sleep(0.1)
                     pipe_input.send_text("foo\r\n")
+                    pipe_input.flush()
                     await asyncio.sleep(0.4)
                     resp = stdout_buf._buffer.getvalue()
                     assert "This console is running in an asyncio event loop." in resp

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -101,7 +101,8 @@ async def invoke_command(
             # In this case, the error is propagated to the upper stack
             # immediately here.
             fut = asyncio.run_coroutine_threadsafe(
-                command_done_event.wait(), monitor._ui_loop  # type: ignore
+                command_done_event.wait(),  # type: ignore
+                monitor._ui_loop,
             )
             await asyncio.wrap_future(fut)
     finally:
@@ -254,8 +255,9 @@ async def test_monitor_with_console(monitor: Monitor) -> None:
                 await asyncio.sleep(0.2)
                 try:
                     pipe_input.send_text("await asyncio.sleep(0.1, result=333)\r\n")
+                    await asyncio.sleep(0.1)
                     pipe_input.send_text("foo\r\n")
-                    await asyncio.sleep(0.25)
+                    await asyncio.sleep(0.4)
                     resp = stdout_buf._buffer.getvalue()
                     assert "This console is running in an asyncio event loop." in resp
                     assert "333" in resp


### PR DESCRIPTION
## What do these changes do?

It improves Python 3.12 compatibility.

This PR relaxes our direct dependency to aiohttp to allow 3.9 and higher, by changing the requirement expression from `~=3.8.5` to `>=3.8.5`, while pinning its version to 3.9.1 in `requirements-dev.txt` used for local development and CI/CD tests. It also pins the uvloop version to 0.19.0 in the same way.

aiomonitor is a library that can be used various combinations of Python and aiohttp versions. The new aiohttp 3.9 release is required to run on Python 3.12, and there is no critical need to hold the aiohttp version back to the 3.8.x series to serve our webui.

In general, it is better to set the minimum compatible versions on our dependencies to maximize the dependency compatibility unless there are known critical regressions on specific versions.

This PR also sets the minimum required version of aioconsole to 0.7.0, to avoid the incompatibility issue with Python 3.11.7+ and 3.12.1+ (vxgmichel/aioconsole#114).

## Are there changes in behavior for the user?

No.

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
