### PR TITLE
Update dev/build dependencies to work better with Python 3.12

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,13 +10,13 @@ repos:
   - id: end-of-file-fixer
   - id: trailing-whitespace
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.1.9
+  rev: v0.3.7
   hooks:
   - id: ruff
     args: ['--fix']
   - id: ruff-format
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.8.0
+  rev: v1.9.0
   hooks:
   - id: mypy
     additional_dependencies:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2"]
+requires = ["setuptools>=69.2", "setuptools_scm[toml]>=8.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,19 +1,19 @@
 -e .
 aioconsole==0.7.0
-aiohttp==3.9.1
-aiotools==1.6.0
+aiohttp==3.9.3
+aiotools==1.7.0
 attrs==23.1.0
 docutils==0.19
 ipdb==0.13.13
-mypy==1.7.1
-pre-commit==3.3.3
+mypy==1.9.0
+pre-commit==3.7.0
 pytest-asyncio==0.21.1
 pytest-cov==4.0.0
 pytest-sugar==0.9.7
 pytest==7.4.0
-ruff==0.1.7
+ruff==0.3.7
 terminaltables==3.1.10
 towncrier==23.6.0
 types-requests
 uvloop==0.19.0
-build==0.10.0
+build==1.2.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ attrs==23.1.0
 docutils==0.19
 ipdb==0.13.13
 mypy==1.9.0
-pre-commit==3.7.0
+pre-commit==3.5.0
 pytest-asyncio==0.21.1
 pytest-cov==4.0.0
 pytest-sugar==0.9.7


### PR DESCRIPTION
## What do these changes do?

This PR updates dev/build dependencies in `requirements-dev.txt` and `pyproject.toml` to work better with Python 3.12.
Though, it does NOT change the minimum requirements of runtime dependencies in `setup.cfg`.

For example, `setuptools` needs to be later than v66.2 as it fixes use of `pkgutil.ImpImporter` deprecated in Python 3.12.
(reference: https://github.com/pypa/pip/issues/11501#issuecomment-1562688616)

`pre-commit` in `requirements-dev.txt` is pinned to v3.5.0 as it dropped the support for Python 3.8 since v3.6.0.

## Are there changes in behavior for the user?

There should be no functional changes in the user side.

## Checklist

- [x] I think the code is well written
