### PR TITLE
Implement a telemetry interface (including Prometheus)

### DIFF
--- a/aiomonitor/telemetry/app.py
+++ b/aiomonitor/telemetry/app.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import dataclasses
+from typing import TYPE_CHECKING
+
+from .prometheus import prometheus_exporter
+
+if TYPE_CHECKING:
+    from ..monitor import Monitor
+
+from aiohttp import web
+
+
+@dataclasses.dataclass
+class TelemetryContext:
+    monitor: Monitor
+
+
+async def init_telemetry(monitor: Monitor) -> web.Application:
+    app = web.Application()
+    app["ctx"] = TelemetryContext(
+        monitor=monitor,
+    )
+    app.router.add_route("GET", "/prometheus", prometheus_exporter)
+    return app

--- a/aiomonitor/telemetry/prometheus.py
+++ b/aiomonitor/telemetry/prometheus.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import asyncio
+import io
+import time
+from typing import TYPE_CHECKING
+
+from aiohttp import web
+
+if TYPE_CHECKING:
+    from .app import TelemetryContext
+
+
+async def prometheus_exporter(request: web.Request) -> web.Response:
+    ctx: TelemetryContext = request.app["ctx"]
+    out = io.StringIO()
+    print("# TYPE asyncio_tasks gauge", file=out)
+    now = time.time_ns() // 1000  # unix timestamp in msec
+    all_task_count = len(asyncio.all_tasks(ctx.monitor._monitored_loop))
+    print(f"asyncio_running_tasks {all_task_count} {now}", file=out)
+    # TODO: count per name of explicitly named tasks (using labels)
+    return web.Response(body=out.getvalue())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,9 @@ ignore = ["E203", "E731", "E501", "Q000"]
 known-first-party = ["aiomonitor"]
 split-on-trailing-comma = true
 
+[tool.ruff.format]
+preview = true  # enable the black's preview style
+
 [tool.mypy]
 ignore_missing_imports = true
 


### PR DESCRIPTION
## What do these changes do?

This PR adds a separate endpoint to serve various telemetry inspection.
The first target will be Prometheus.

## Are there changes in behavior for the user?

Users will become able to connect various metric dashboards to monitor asyncio apps.

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
