### PR TITLE
fix: resolve DeprecationWarning for click.parser.split_arg_string import

### DIFF
--- a/changes/452.fix
+++ b/changes/452.fix
@@ -1,0 +1,1 @@
+Fix DeprecationWarning for ``split_arg_string`` import from ``click.parser`` by using ``click.shell_completion`` instead


### PR DESCRIPTION
Closes #452

## Problem Analysis

When importing aiomonitor v0.7.1 with Click 8.x, a `DeprecationWarning` is raised:

```
aiomonitor/termui/completion.py:8: DeprecationWarning: Importing 'parser.split_arg_string'
is deprecated, it will only be available in 'shell_completion' in Click 9.0.
  from click.parser import split_arg_string
```

The root cause was that `split_arg_string` was imported from `click.parser` (the deprecated
location) while the other completion utilities (`CompletionItem`, `_resolve_context`,
`_resolve_incomplete`) were already correctly imported from `click.shell_completion`.

## Solution

The code fix was already applied in commit 4d8cd2a ("First rudimentary version of the web
UI (#371)"), which consolidated all completion-related imports under `click.shell_completion`.

This PR adds the missing **changelog fragment** (`changes/452.fix`) to document the fix for
release notes.

## Changes

- `changes/452.fix` — new changelog fragment documenting the deprecation warning fix

## Verification

- Running `python -X dev -c 'import aiomonitor'` on main produces no `split_arg_string`
  deprecation warning
- All imports from `click.shell_completion` work correctly with Click 8.3.1+
- `split_arg_string` has been available in `click.shell_completion` since Click 8.0

## Checklist

- [x] All linting passes (`ruff check`, `ruff format --check`)
- [x] Type checking passes (`mypy`)
- [x] All tests pass (`pytest`) — 1 pre-existing failure in `test_monitor_with_console` (aioconsole/Python 3.14 compat issue, unrelated)
- [x] Changelog fragment added (`changes/452.fix`)
- [x] No unrelated changes included