### PR TITLE
Add read-only mode for termui and webui

### DIFF
--- a/aiomonitor/monitor.py
+++ b/aiomonitor/monitor.py
@@ -648,7 +648,9 @@ def start_monitor(
     Factory function, creates instance of :class:`Monitor` and starts
     monitoring thread.
 
-    :param Type[Monitor] monitor: Monitor class to use
+    :param Type[Monitor] monitor: Monitor class to use. This is primarily an
+        internal extension hook; custom monitor classes must keep a constructor
+        signature compatible with :class:`Monitor`, including ``readonly``.
     :param str host: hostname to serve monitor telnet server
     :param int port: monitor port (terminal UI), by default 20101
     :param int webui_port: monitor port (web UI), by default 20102

--- a/aiomonitor/termui/commands.py
+++ b/aiomonitor/termui/commands.py
@@ -372,6 +372,7 @@ def do_console(ctx: click.Context) -> None:
         return
     if not self._console_enabled:
         print_fail("Python console is disabled for this session!")
+        command_done.get().set()
         return
 
     @auto_async_command_done

--- a/aiomonitor/termui/commands.py
+++ b/aiomonitor/termui/commands.py
@@ -35,6 +35,8 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
+_READONLY_MSG = "This command is not available in read-only mode."
+
 __all__ = (
     "interact",
     "monitor_cli",
@@ -308,7 +310,7 @@ def do_signal(ctx: click.Context, signame: str) -> None:
     """Send a Unix signal"""
     self: Monitor = ctx.obj
     if self._readonly:
-        print_fail("This command is not available in read-only mode.")
+        print_fail(_READONLY_MSG)
         return
     if hasattr(signal, signame):
         os.kill(os.getpid(), getattr(signal, signame))
@@ -337,7 +339,7 @@ def do_cancel(ctx: click.Context, taskid: str) -> None:
     """Cancel an indicated task"""
     self: Monitor = ctx.obj
     if self._readonly:
-        print_fail("This command is not available in read-only mode.")
+        print_fail(_READONLY_MSG)
         command_done.get().set()
         return
 
@@ -367,7 +369,7 @@ def do_console(ctx: click.Context) -> None:
     """Switch to async Python REPL"""
     self: Monitor = ctx.obj
     if self._readonly:
-        print_fail("This command is not available in read-only mode.")
+        print_fail(_READONLY_MSG)
         command_done.get().set()
         return
     if not self._console_enabled:

--- a/aiomonitor/webui/app.py
+++ b/aiomonitor/webui/app.py
@@ -97,6 +97,7 @@ async def show_list_page(request: web.Request) -> web.Response:
                 {"id": TaskTypes.RUNNING, "title": "Running"},
                 {"id": TaskTypes.TERMINATED, "title": "Terminated"},
             ],
+            readonly=ctx.monitor._readonly,
         )
         return web.Response(body=output, content_type="text/html")
 
@@ -208,6 +209,11 @@ async def get_terminated_task_list(request: web.Request) -> web.Response:
 
 async def cancel_task(request: web.Request) -> web.Response:
     ctx: WebUIContext = request.app[ctx_key]
+    if ctx.monitor._readonly:
+        return web.json_response(
+            status=403,
+            data={"msg": "Cannot cancel tasks in read-only mode"},
+        )
     async with check_params(request, TaskIdParams) as params:
         try:
             coro_repr = await ctx.monitor.cancel_monitored_task(params.task_id)

--- a/aiomonitor/webui/templates/index.html
+++ b/aiomonitor/webui/templates/index.html
@@ -26,6 +26,7 @@
 {% endblock %}
 {% block content %}
 {% if readonly %}
+<style>.task-cancel-btn { display: none !important; }</style>
 <div class="rounded-md bg-yellow-50 p-3 mb-4">
   <div class="flex">
     <div class="flex-shrink-0">
@@ -129,8 +130,7 @@
     {{^is_root}}
     <button
       type="button"
-      x-data x-show="!$store.config.readonly"
-      class="notify-result rounded bg-rose-600 px-2 py-1 text-xs font-semibold text-white shadow-sm hover:bg-rose-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-600 disabled:opacity-50"
+      class="task-cancel-btn notify-result rounded bg-rose-600 px-2 py-1 text-xs font-semibold text-white shadow-sm hover:bg-rose-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-600 disabled:opacity-50"
       hx-delete="/api/task"
       hx-params="not persistent,filter"
       hx-vals='{"task_id": "{{ task_id }}"}'
@@ -251,9 +251,6 @@
   document.addEventListener("alpine:init", () => {
     Alpine.store("filters", {
       persistent: false,
-    });
-    Alpine.store("config", {
-      readonly: {{ "true" if readonly else "false" }},
     });
     console.log("init filters")
   });

--- a/aiomonitor/webui/templates/index.html
+++ b/aiomonitor/webui/templates/index.html
@@ -25,6 +25,20 @@
 </div>
 {% endblock %}
 {% block content %}
+{% if readonly %}
+<div class="rounded-md bg-yellow-50 p-3 mb-4">
+  <div class="flex">
+    <div class="flex-shrink-0">
+      <svg class="h-5 w-5 text-yellow-400" viewBox="0 0 20 20" fill="currentColor">
+        <path fill-rule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd" />
+      </svg>
+    </div>
+    <div class="ml-3">
+      <p class="text-sm font-medium text-yellow-800">Read-only mode: Task cancellation and other destructive operations are disabled.</p>
+    </div>
+  </div>
+</div>
+{% endif %}
 {% if current_list_type == "running" %}
 <div class="flex space-x-2 divide-x divide-gray-200">
   <div class="py-2 px-2">
@@ -115,6 +129,7 @@
     {{^is_root}}
     <button
       type="button"
+      x-data x-show="!$store.config.readonly"
       class="notify-result rounded bg-rose-600 px-2 py-1 text-xs font-semibold text-white shadow-sm hover:bg-rose-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-600 disabled:opacity-50"
       hx-delete="/api/task"
       hx-params="not persistent,filter"
@@ -236,6 +251,9 @@
   document.addEventListener("alpine:init", () => {
     Alpine.store("filters", {
       persistent: false,
+    });
+    Alpine.store("config", {
+      readonly: {{ "true" if readonly else "false" }},
     });
     console.log("init filters")
   });

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -29,7 +29,7 @@ from aiomonitor.termui.commands import (
 
 
 @contextlib.contextmanager
-def monitor_common():
+def monitor_common(readonly: bool = False):
     def make_baz():
         return "baz"
 
@@ -40,7 +40,7 @@ def monitor_common():
     # > fut = asyncio.wrap_future(asyncio.run_coroutine_threadsafe(...))
     # > await fut
     test_loop = asyncio.get_running_loop()
-    mon = Monitor(test_loop, locals=locals_)
+    mon = Monitor(test_loop, locals=locals_, readonly=readonly)
     with mon:
         yield mon
 
@@ -48,6 +48,12 @@ def monitor_common():
 @pytest.fixture
 async def monitor(request, event_loop):
     with monitor_common() as monitor_instance:
+        yield monitor_instance
+
+
+@pytest.fixture
+async def readonly_monitor(request, event_loop):
+    with monitor_common(readonly=True) as monitor_instance:
         yield monitor_instance
 
 
@@ -286,3 +292,68 @@ async def test_custom_monitor_command(monitor: Monitor):
 
     resp = await invoke_command(monitor, ["something", "someargument"])
     assert "doing something with someargument" in resp
+
+
+@pytest.mark.asyncio
+async def test_readonly_cancel_termui(readonly_monitor: Monitor) -> None:
+    async def sleeper():
+        await asyncio.sleep(100)
+
+    test_loop = readonly_monitor._monitored_loop
+    t = test_loop.create_task(sleeper())
+    t_id = id(t)
+    await asyncio.sleep(0.1)
+
+    resp = await invoke_command(readonly_monitor, ["cancel", str(t_id)])
+    assert "not available in read-only mode" in resp
+    assert not t.done()
+    t.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await t
+
+
+@pytest.mark.asyncio
+async def test_readonly_signal_termui(readonly_monitor: Monitor) -> None:
+    resp = await invoke_command(readonly_monitor, ["signal", "SIGUSR1"])
+    assert "not available in read-only mode" in resp
+
+
+@pytest.mark.asyncio
+async def test_readonly_console_termui(readonly_monitor: Monitor) -> None:
+    resp = await invoke_command(readonly_monitor, ["console"])
+    assert "not available in read-only mode" in resp
+
+
+@pytest.mark.asyncio
+async def test_readonly_cancel_monitored_task(readonly_monitor: Monitor) -> None:
+    async def sleeper():
+        await asyncio.sleep(100)
+
+    test_loop = readonly_monitor._monitored_loop
+    t = test_loop.create_task(sleeper())
+    t_id = id(t)
+    await asyncio.sleep(0.1)
+
+    with pytest.raises(PermissionError, match="read-only mode"):
+        await readonly_monitor.cancel_monitored_task(t_id)
+    assert not t.done()
+    t.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await t
+
+
+@pytest.mark.asyncio
+async def test_readonly_ps_still_works(readonly_monitor: Monitor) -> None:
+    resp = await invoke_command(readonly_monitor, ["ps"])
+    assert "tasks running" in resp
+
+
+@pytest.mark.asyncio
+async def test_readonly_ctor() -> None:
+    test_loop = asyncio.get_running_loop()
+    with Monitor(test_loop, readonly=True) as m:
+        assert m._readonly is True
+        await asyncio.sleep(0.01)
+    with Monitor(test_loop, readonly=False) as m:
+        assert m._readonly is False
+        await asyncio.sleep(0.01)

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -296,16 +296,19 @@ async def test_custom_monitor_command(monitor: Monitor):
     assert "doing something with someargument" in resp
 
 
-@pytest.mark.asyncio
-async def test_readonly_cancel_termui(readonly_monitor: Monitor) -> None:
-    async def sleeper():
+async def _create_sleeper_task(monitor: Monitor) -> tuple[asyncio.Task[None], int]:
+    async def sleeper() -> None:
         await asyncio.sleep(100)
 
-    test_loop = readonly_monitor._monitored_loop
-    t = test_loop.create_task(sleeper())
+    t = monitor._monitored_loop.create_task(sleeper())
     t_id = id(t)
     await asyncio.sleep(0.1)
+    return t, t_id
 
+
+@pytest.mark.asyncio
+async def test_readonly_cancel_termui(readonly_monitor: Monitor) -> None:
+    t, t_id = await _create_sleeper_task(readonly_monitor)
     resp = await invoke_command(readonly_monitor, ["cancel", str(t_id)])
     assert "not available in read-only mode" in resp
     assert not t.done()
@@ -315,27 +318,19 @@ async def test_readonly_cancel_termui(readonly_monitor: Monitor) -> None:
 
 
 @pytest.mark.asyncio
-async def test_readonly_signal_termui(readonly_monitor: Monitor) -> None:
-    resp = await invoke_command(readonly_monitor, ["signal", "SIGUSR1"])
-    assert "not available in read-only mode" in resp
-
-
-@pytest.mark.asyncio
-async def test_readonly_console_termui(readonly_monitor: Monitor) -> None:
-    resp = await invoke_command(readonly_monitor, ["console"])
+@pytest.mark.parametrize(
+    "command", [["signal", "SIGUSR1"], ["console"]], ids=["signal", "console"]
+)
+async def test_readonly_simple_termui_commands(
+    readonly_monitor: Monitor, command: list[str]
+) -> None:
+    resp = await invoke_command(readonly_monitor, command)
     assert "not available in read-only mode" in resp
 
 
 @pytest.mark.asyncio
 async def test_readonly_cancel_monitored_task(readonly_monitor: Monitor) -> None:
-    async def sleeper():
-        await asyncio.sleep(100)
-
-    test_loop = readonly_monitor._monitored_loop
-    t = test_loop.create_task(sleeper())
-    t_id = id(t)
-    await asyncio.sleep(0.1)
-
+    t, t_id = await _create_sleeper_task(readonly_monitor)
     with pytest.raises(PermissionError, match="read-only mode"):
         await readonly_monitor.cancel_monitored_task(t_id)
     assert not t.done()
@@ -351,13 +346,11 @@ async def test_readonly_ps_still_works(readonly_monitor: Monitor) -> None:
 
 
 @pytest.mark.asyncio
-async def test_readonly_ctor() -> None:
+@pytest.mark.parametrize("readonly", [True, False])
+async def test_readonly_ctor(readonly: bool) -> None:
     test_loop = asyncio.get_running_loop()
-    with Monitor(test_loop, readonly=True) as m:
-        assert m._readonly is True
-        await asyncio.sleep(0.01)
-    with Monitor(test_loop, readonly=False) as m:
-        assert m._readonly is False
+    with Monitor(test_loop, readonly=readonly) as m:
+        assert m._readonly is readonly
         await asyncio.sleep(0.01)
 
 


### PR DESCRIPTION
Resolves #386

## Summary
Add a `readonly` parameter to `Monitor` and `start_monitor()` that, when `True`, prevents destructive operations (task cancellation, signal sending, console access) in both the terminal UI and web UI. This protects production environments from accidental task cancellation.

## Implementation Plan

### Approach
Thread a `readonly` boolean through `Monitor.__init__()` and `start_monitor()` that guards destructive commands in termui (`cancel`, `signal`, `console`) and the webui cancel endpoint (`DELETE /api/task`), while hiding cancel buttons in the frontend.

### Steps
1. **`monitor.py`**: Add `readonly` parameter to `Monitor.__init__` and `start_monitor`; add guard in `cancel_monitored_task`
2. **`termui/commands.py`**: Add read-only guards to `do_cancel`, `do_signal`, `do_console`; update intro message
3. **`webui/app.py`**: Guard `cancel_task` endpoint with 403; pass `readonly` to template; add `readonly` to `WebUIContext`
4. **`webui/templates/index.html`**: Hide cancel button via Alpine.js store; add read-only banner
5. **`tests/test_monitor.py`**: Add tests for read-only behavior

### Files to Modify
- `aiomonitor/monitor.py` — Add `readonly` param, property, and defense-in-depth guard
- `aiomonitor/termui/commands.py` — Guard `do_cancel`, `do_signal`, `do_console`
- `aiomonitor/webui/app.py` — Guard cancel endpoint, pass readonly to template
- `aiomonitor/webui/templates/index.html` — Conditional cancel button, read-only banner
- `tests/test_monitor.py` — New tests for read-only mode

### Edge Cases
- Backward compatibility: `readonly` defaults to `False`
- Defense-in-depth: `cancel_monitored_task` raises `PermissionError` even if UI guards are bypassed
- `command_done` event handling for commands that don't use `@auto_command_done`
- Mustache templates are client-side rendered, so Alpine.js store is used for conditional rendering

## Test Plan
- [ ] Test `Monitor(loop, readonly=True)` constructor
- [ ] Test `cancel` command rejected in read-only mode
- [ ] Test `signal` command rejected in read-only mode
- [ ] Test `console` command rejected in read-only mode
- [ ] Test `cancel_monitored_task` raises `PermissionError` in read-only mode
- [ ] Test read-only commands (`ps`, `where`, etc.) still work in read-only mode
- [ ] Test webui cancel endpoint returns 403 in read-only mode